### PR TITLE
Add ssh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # ffs
 
-ffs is a Fast Fuzzing Service CLI that runs your campaigns on the cloud
+ffs is a Fast Fuzzing Service CLI that runs your campaigns on the cloud.
+
+## SSH into a job
+
+After listing jobs with `ffs ls`, you can quickly connect to one by ID:
+
+```bash
+ffs ssh <job-id>
+```
+
+This runs `ssh root@<job-ip>` using the job's public IPv4 address.

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             println!("Fetching logs for job {id} at {filename}");
             provider.tail(&id, &filename).await?;
         }
+        "ssh" => {
+            let id = args.get(2).unwrap().to_string();
+            match provider.get_job(&id).await? {
+                Some(job) => {
+                    println!("Connecting to {}", job.ipv4);
+                    std::process::Command::new("ssh")
+                        .arg(format!("root@{}", job.ipv4))
+                        .status()?;
+                }
+                None => println!("Job {id} not found"),
+            }
+        }
         _ => {
             println!("Invalid action");
         }


### PR DESCRIPTION
## Summary
- add `ssh` command for quickly connecting to a job
- document usage of the new command in README

## Testing
- `cargo check -q`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68497780686c8332bb9a1b4735876a2c