### PR TITLE
Restore AWS provider skeleton

### DIFF
--- a/src/providers/hetzner/mod.rs
+++ b/src/providers/hetzner/mod.rs
@@ -39,6 +39,13 @@ impl Provider for HetznerProvider {
             name: Some(name.to_string()),
         };
 
+        let ip = job.ipv4.clone();
+        let key_path = config.ssh_key_path.clone();
+        let provider = self.clone();
+        tokio::spawn(async move {
+            let _ = provider.install_dependencies(&ip, &key_path).await;
+        });
+
         Ok(job)
     }
 
@@ -151,6 +158,7 @@ impl Provider for HetznerProvider {
 fn config() -> Result<Config, Box<dyn std::error::Error + Send + Sync>> {
     config::load_config("./config.toml")
 }
+#[derive(Clone)]
 pub struct HetznerProvider {}
 
 impl HetznerProvider {


### PR DESCRIPTION
## Summary
- keep incomplete `AWSProvider` trait impl
- restore AWS option in CLI provider selection
- share install script via `install_dependencies` default trait method
- spawn dependency install after creating Hetzner job

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6849772ffd288332926c1177d182d55e