### PR TITLE
Streamline CI publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,32 @@ jobs:
 
   publish:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Install cargo-bump
+        run: cargo install cargo-bump
+      - name: Bump version
+        run: cargo bump patch
+      - name: Get version
+        id: version
+        run: echo "VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')" >> $GITHUB_OUTPUT
+      - name: Commit version bump
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add Cargo.toml
+          git commit -m "Bump version to v${{ steps.version.outputs.VERSION }}"
+          git tag "v${{ steps.version.outputs.VERSION }}"
+          git push origin main --tags
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Auto-bump patch version on every push to main branch
- Auto-commit version changes and create git tags
- Auto-publish to crates.io after successful builds and tests
- Remove manual tag requirement for publishing

## Changes
- Modified `.github/workflows/ci.yml` to trigger publish job on main branch pushes instead of tags
- Added `cargo-bump` installation and version bumping steps
- Added automatic git commit and tag creation for version bumps
- Streamlined the publishing process to be fully automated

## Test plan
- [ ] Verify CI workflow runs on main branch pushes
- [ ] Confirm version bumping works correctly
- [ ] Test that git commits and tags are created automatically
- [ ] Validate publishing to crates.io works with `CARGO_REGISTRY_TOKEN`

🤖 Generated with [Claude Code](https://claude.ai/code)